### PR TITLE
Cobertura is dead - discourage its use

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ To run
 ### Features
 
 * Supports
-  [Cobertura](https://www.mojohaus.org/cobertura-maven-plugin/),
   [JaCoCo](https://www.eclemma.org/jacoco/trunk/doc/maven.html),
+  [Cobertura](https://www.mojohaus.org/cobertura-maven-plugin/)*, 
   [Saga](https://timurstrekalov.github.io/saga/), and
   [Clover](https://openclover.org/) coverage tools
 * Multi-module report aggregation
@@ -42,6 +42,7 @@ To run
 * Convention over configuration for almost zero configuration usage
 * Applies [semantic versioning](https://semver.org/)
 
+_*Note that Cobertura and the related Maven plugin have not had updates in 10 years and should be considered deprecated_
 
 ### Usage
 
@@ -108,6 +109,7 @@ after_success:
   - mvn clean cobertura:cobertura coveralls:report
 ```
 
+Cobertura use is not recommended as the project has not seen a new release since 2015
 
 #### JaCoCo
 

--- a/src/main/java/org/eluder/coveralls/maven/plugin/CoverallsReportMojo.java
+++ b/src/main/java/org/eluder/coveralls/maven/plugin/CoverallsReportMojo.java
@@ -81,6 +81,7 @@ public class CoverallsReportMojo extends AbstractMojo {
      * File paths to additional Cobertura coverage report files.
      */
     @Parameter(property = "coberturaReports")
+    @Deprecated
     private List<File> coberturaReports;
 
     /**

--- a/src/main/java/org/eluder/coveralls/maven/plugin/parser/CoberturaParser.java
+++ b/src/main/java/org/eluder/coveralls/maven/plugin/parser/CoberturaParser.java
@@ -37,7 +37,9 @@ import org.eluder.coveralls.maven.plugin.source.SourceLoader;
 
 /**
  * The Class CoberturaParser.
+ * Cobertura is no longer maintained so this may be dropped in a future release
  */
+@Deprecated
 public class CoberturaParser extends AbstractXmlEventParser {
 
     /** The source. */


### PR DESCRIPTION
Cobertura has not been getting updates releases in 10 years and is pretty broken on modern Java. It should not be recommended for use. I'd suggest not attempting to do too much to support it. Perhaps leave the related code in place for now but if it becomes a problem just rip it out completely.